### PR TITLE
Hotfix/#28

### DIFF
--- a/src/main/java/com/slcube/shop/business/address/domain/Address.java
+++ b/src/main/java/com/slcube/shop/business/address/domain/Address.java
@@ -1,6 +1,5 @@
 package com.slcube.shop.business.address.domain;
 
-import com.slcube.shop.business.member.domain.Member;
 import com.slcube.shop.common.config.jpa.BooleanToYnConverter;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -34,18 +33,16 @@ public class Address {
     @Convert(converter = BooleanToYnConverter.class)
     private Boolean isDefaultAddress;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
-    private Member member;
+    private Long memberId;
 
     @Builder
-    private Address(String city, String zipcode, String street, String comment, boolean isDefaultAddress, Member member) {
+    private Address(String city, String zipcode, String street, String comment, boolean isDefaultAddress, Long memberId) {
         this.city = city;
         this.zipcode = zipcode;
         this.street = street;
         this.comment = comment;
         this.isDefaultAddress = isDefaultAddress;
-        this.member = member;
+        this.memberId = memberId;
     }
 
     public void updateAddress(String city, String zipcode, String street, String comment, boolean isDefaultAddress) {

--- a/src/main/java/com/slcube/shop/business/cart/controller/CartController.java
+++ b/src/main/java/com/slcube/shop/business/cart/controller/CartController.java
@@ -4,7 +4,7 @@ import com.slcube.shop.business.cart.dto.CartListResponseDto;
 import com.slcube.shop.business.cart.dto.CartSaveRequestDto;
 import com.slcube.shop.business.cart.dto.CartUpdateRequestDto;
 import com.slcube.shop.business.cart.service.CartService;
-import com.slcube.shop.common.security.authenticationContext.MemberContext;
+import com.slcube.shop.business.member.dto.MemberSessionDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -21,13 +21,13 @@ public class CartController {
     private final CartService cartService;
 
     @PostMapping
-    public Long saveCart(@RequestBody @Valid CartSaveRequestDto requestDto, @AuthenticationPrincipal MemberContext memberContext) {
-        return cartService.saveCart(requestDto, memberContext.getMember());
+    public Long saveCart(@RequestBody @Valid CartSaveRequestDto requestDto, @AuthenticationPrincipal MemberSessionDto sessionDto) {
+        return cartService.saveCart(requestDto, sessionDto);
     }
 
     @GetMapping
-    public Page<CartListResponseDto> findAllCarts(@AuthenticationPrincipal MemberContext memberContext, Pageable pageable) {
-        return cartService.findAllCarts(memberContext.getMember(), pageable);
+    public Page<CartListResponseDto> findAllCarts(@AuthenticationPrincipal MemberSessionDto sessionDto, Pageable pageable) {
+        return cartService.findAllCarts(sessionDto, pageable);
     }
 
     @PatchMapping("/{cartId}")

--- a/src/main/java/com/slcube/shop/business/cart/domain/Cart.java
+++ b/src/main/java/com/slcube/shop/business/cart/domain/Cart.java
@@ -3,7 +3,6 @@ package com.slcube.shop.business.cart.domain;
 import com.slcube.shop.business.item.domain.Item;
 import com.slcube.shop.common.config.jpa.BooleanToYnConverter;
 import com.slcube.shop.common.domain.BaseEntity;
-import com.slcube.shop.business.member.domain.Member;
 import lombok.Getter;
 
 import javax.persistence.*;
@@ -21,9 +20,7 @@ public class Cart extends BaseEntity {
     @JoinColumn(name = "item_id")
     private Item item;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
-    private Member member;
+    private Long memberId;
 
     @Column(nullable = false)
     private int quantity;
@@ -36,14 +33,14 @@ public class Cart extends BaseEntity {
         this.quantity = 1;
     }
 
-    private Cart(Item item, int quantity, Member member) {
+    private Cart(Item item, int quantity, Long memberId) {
         this.item = item;
         this.quantity = quantity;
-        this.member = member;
+        this.memberId = memberId;
     }
 
-    public static Cart createCartItem(Item item, int quantity, Member member) {
-        Cart cart = new Cart(item, quantity, member);
+    public static Cart createCartItem(Item item, int quantity, Long memberId) {
+        Cart cart = new Cart(item, quantity, memberId);
         return cart;
     }
 

--- a/src/main/java/com/slcube/shop/business/cart/repository/CartRepository.java
+++ b/src/main/java/com/slcube/shop/business/cart/repository/CartRepository.java
@@ -1,7 +1,6 @@
 package com.slcube.shop.business.cart.repository;
 
 import com.slcube.shop.business.cart.domain.Cart;
-import com.slcube.shop.business.member.domain.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,6 +14,6 @@ public interface CartRepository extends JpaRepository<Cart, Long> {
     @Query("select c from Cart c where c.id = :cartId and c.isDeleted = false")
     Optional<Cart> findByNotDeleted(@Param("cartId") Long cartId);
 
-    @Query("select c from Cart c where c.member = :member and c.isDeleted = false")
-    Page<Cart> findAllCarts(@Param("member") Member member, Pageable pageable);
+    @Query("select c from Cart c where c.memberId = :memberId and c.isDeleted = false")
+    Page<Cart> findAllCarts(@Param("memberId") Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/slcube/shop/business/cart/service/CartService.java
+++ b/src/main/java/com/slcube/shop/business/cart/service/CartService.java
@@ -4,7 +4,7 @@ import com.slcube.shop.business.cart.dto.CartListResponseDto;
 import com.slcube.shop.business.cart.dto.CartResponseDto;
 import com.slcube.shop.business.cart.dto.CartSaveRequestDto;
 import com.slcube.shop.business.cart.dto.CartUpdateRequestDto;
-import com.slcube.shop.business.member.domain.Member;
+import com.slcube.shop.business.member.dto.MemberSessionDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -12,9 +12,9 @@ import org.springframework.stereotype.Service;
 @Service
 public interface CartService {
 
-    Long saveCart(CartSaveRequestDto requestDto, Member member);
+    Long saveCart(CartSaveRequestDto requestDto, MemberSessionDto sessionDto);
     CartResponseDto findCart(Long cartId);
-    Page<CartListResponseDto> findAllCarts(Member member, Pageable pageable);
+    Page<CartListResponseDto> findAllCarts(MemberSessionDto sessionDto, Pageable pageable);
     Long updateCart(Long cartId, CartUpdateRequestDto requestDto);
     Long deleteCart(Long cartId);
 }

--- a/src/main/java/com/slcube/shop/business/cart/service/CartServiceImpl.java
+++ b/src/main/java/com/slcube/shop/business/cart/service/CartServiceImpl.java
@@ -10,7 +10,7 @@ import com.slcube.shop.business.cart.repository.CartRepositoryHelper;
 import com.slcube.shop.business.item.domain.Item;
 import com.slcube.shop.business.item.repository.ItemRepository;
 import com.slcube.shop.business.item.repository.ItemRepositoryHelper;
-import com.slcube.shop.business.member.domain.Member;
+import com.slcube.shop.business.member.dto.MemberSessionDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -29,12 +29,12 @@ public class CartServiceImpl implements CartService {
 
     @Override
     @Transactional
-    public Long saveCart(CartSaveRequestDto requestDto, Member member) {
+    public Long saveCart(CartSaveRequestDto requestDto, MemberSessionDto sessionDto) {
         Long itemId = requestDto.getItemId();
         int quantity = requestDto.getQuantity();
 
         Item item = itemRepositoryHelper.findByNotDeleted(itemRepository, itemId);
-        Cart cart = Cart.createCartItem(item, quantity, member);
+        Cart cart = Cart.createCartItem(item, quantity, sessionDto.getMemberId());
 
         return cartRepository.save(cart).getId();
     }
@@ -46,8 +46,8 @@ public class CartServiceImpl implements CartService {
     }
 
     @Override
-    public Page<CartListResponseDto> findAllCarts(Member member, Pageable pageable) {
-        return cartRepository.findAllCarts(member, pageable)
+    public Page<CartListResponseDto> findAllCarts(MemberSessionDto sessionDto, Pageable pageable) {
+        return cartRepository.findAllCarts(sessionDto.getMemberId(), pageable)
                 .map(CartListResponseDto::new);
     }
 

--- a/src/test/java/com/slcube/shop/business/cart/controller/CartControllerTest.java
+++ b/src/test/java/com/slcube/shop/business/cart/controller/CartControllerTest.java
@@ -5,7 +5,7 @@ import com.slcube.shop.business.cart.dto.CartListResponseDto;
 import com.slcube.shop.business.cart.dto.CartSaveRequestDto;
 import com.slcube.shop.business.cart.dto.CartUpdateRequestDto;
 import com.slcube.shop.business.cart.service.CartService;
-import com.slcube.shop.business.member.domain.Member;
+import com.slcube.shop.business.member.dto.MemberSessionDto;
 import com.slcube.shop.common.security.WithMockMember;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,11 +23,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.mockito.BDDMockito.*;
-import static org.springframework.http.MediaType.*;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(CartController.class)
 @WithMockMember
@@ -50,7 +52,7 @@ class CartControllerTest {
         requestDto.setItemId(1L);
         requestDto.setQuantity(10);
 
-        given(cartService.saveCart(any(CartSaveRequestDto.class), any(Member.class)))
+        given(cartService.saveCart(any(CartSaveRequestDto.class), any(MemberSessionDto.class)))
                 .willReturn(cartId);
 
         mockMvc.perform(post("/api/carts")
@@ -76,7 +78,7 @@ class CartControllerTest {
 
         PageImpl<CartListResponseDto> result = new PageImpl<>(carts, pageable, carts.size());
 
-        given(cartService.findAllCarts(any(Member.class), any(Pageable.class)))
+        given(cartService.findAllCarts(any(MemberSessionDto.class), any(Pageable.class)))
                 .willReturn(result);
 
         MultiValueMap<String, String> requestParam = new LinkedMultiValueMap<>();

--- a/src/test/java/com/slcube/shop/business/cart/service/CartServiceImplTest.java
+++ b/src/test/java/com/slcube/shop/business/cart/service/CartServiceImplTest.java
@@ -6,10 +6,10 @@ import com.slcube.shop.business.cart.dto.CartUpdateRequestDto;
 import com.slcube.shop.business.item.domain.Item;
 import com.slcube.shop.business.item.repository.ItemRepository;
 import com.slcube.shop.business.member.domain.Member;
+import com.slcube.shop.business.member.dto.MemberSessionDto;
 import com.slcube.shop.business.member.repository.MemberRepository;
 import com.slcube.shop.common.exception.CartItemNotFoundException;
 import com.slcube.shop.common.security.WithMockMember;
-import com.slcube.shop.common.security.authenticationContext.MemberContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,8 +18,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 @Transactional
@@ -49,8 +50,13 @@ class CartServiceImplTest {
 
         itemId = itemRepository.save(item).getId();
 
-        MemberContext memberContext = (MemberContext) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        member = memberContext.getMember();
+        MemberSessionDto sessionDto = (MemberSessionDto) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        member = Member.builder()
+                .email(sessionDto.getLoginEmail())
+                .username(sessionDto.getUsername())
+                .password("test password")
+                .build();
+
         memberRepository.save(member);
     }
 
@@ -106,7 +112,8 @@ class CartServiceImplTest {
     }
 
     private Long saveCart() {
+        MemberSessionDto sessionDto = new MemberSessionDto(member);
         CartSaveRequestDto requestDto = createCartItem();
-        return cartService.saveCart(requestDto, member);
+        return cartService.saveCart(requestDto, sessionDto);
     }
 }


### PR DESCRIPTION
Session Storage에 저장하는 데이터를 Member Entity에서 Dto로 변경하면서 누락된 수정사항을 반영했습니다.

추가로 Address -> Member, Cart -> Member사이의 연관관계를 직접연관관계에서 간접연관관계로 변경했습니다.